### PR TITLE
Refactor consul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,12 @@
 [[package]]
+name = "MacTypes-sys"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "adler32"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,7 +950,7 @@ dependencies = [
  "openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1488,14 +1496,15 @@ dependencies = [
  "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "MacTypes-sys 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2059,13 +2068,15 @@ dependencies = [
 [[package]]
 name = "tower-consul"
 version = "0.1.0"
-source = "git+https://github.com/LucioFranco/tower-consul#f16e9c75c5726022e84a19a60b1e4553e1b80ae1"
+source = "git+https://github.com/LucioFranco/tower-consul#0d9a0f9a15dd6010624c7c0da4b6b71803baf95c"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-http 0.1.0 (git+https://github.com/tower-rs/tower-http)",
+ "tower-service 0.2.0 (git+https://github.com/tower-rs/tower)",
 ]
 
 [[package]]
@@ -2400,6 +2411,7 @@ dependencies = [
 ]
 
 [metadata]
+"checksum MacTypes-sys 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7dbbe033994ae2198a18517c7132d952a29fb1db44249a1234779da7c50f4698"
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
@@ -2575,7 +2587,7 @@ dependencies = [
 "checksum schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum security-framework 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "697d3f3c23a618272ead9e1fb259c1411102b31c6af8b93f1d64cca9c3b0e8e0"
-"checksum security-framework-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab01dfbe5756785b5b4d46e0289e5a18071dfa9a7c2b24213ea00b9ef9b665bf"
+"checksum security-framework-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "40d95f3d7da09612affe897f320d78264f0d2320f3e8eea27d12bd1bd94445e2"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "tower-consul"
 version = "0.1.0"
-source = "git+https://github.com/LucioFranco/tower-consul#0d9a0f9a15dd6010624c7c0da4b6b71803baf95c"
+source = "git+https://github.com/LucioFranco/tower-consul#e641279ac3fb90a497abe67084a5a5ee706b943b"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bin/toshi-placement.rs
+++ b/src/bin/toshi-placement.rs
@@ -20,7 +20,11 @@ fn main() {
     info!("Starting Toshi Placement Service...");
     let addr = format!("{}:{}", host, port).parse().unwrap();
     let consul_addr = format!("{}:{}", consul_host, consul_port).parse().unwrap();
-    let consul = Consul::build().with_address(consul_addr).with_scheme(Scheme::HTTP).build().unwrap();
+    let consul = Consul::builder()
+        .with_address(consul_addr)
+        .with_scheme(Scheme::HTTP)
+        .build()
+        .unwrap();
     let service = Place::get_service(addr, consul);
 
     tokio::run(service);

--- a/src/bin/toshi-placement.rs
+++ b/src/bin/toshi-placement.rs
@@ -20,7 +20,7 @@ fn main() {
     info!("Starting Toshi Placement Service...");
     let addr = format!("{}:{}", host, port).parse().unwrap();
     let consul_addr = format!("{}:{}", consul_host, consul_port).parse().unwrap();
-    let consul = Consul::default().with_address(consul_addr).with_scheme(Scheme::HTTP);
+    let consul = Consul::build().with_address(consul_addr).with_scheme(Scheme::HTTP).build().unwrap();
     let service = Place::get_service(addr, consul);
 
     tokio::run(service);

--- a/src/bin/toshi.rs
+++ b/src/bin/toshi.rs
@@ -176,7 +176,11 @@ fn connect_to_consul(settings: &Settings) -> impl Future<Item = (), Error = ()> 
     let settings_path_write = settings.path.clone();
 
     future::lazy(move || {
-        let mut consul_client = Consul::default().with_cluster_name(cluster_name).with_address(consul_address);
+        let mut consul_client = Consul::build()
+            .with_cluster_name(cluster_name)
+            .with_address(consul_address)
+            .build()
+            .unwrap();
 
         // Build future that will connect to consul and register the node_id
         consul_client
@@ -194,7 +198,7 @@ fn connect_to_consul(settings: &Settings) -> impl Future<Item = (), Error = ()> 
                 }
             })
             .and_then(move |id| {
-                consul_client.node_id = Some(id);
+                consul_client.set_node_id(id);
                 consul_client.register_node()
             })
             .map_err(|e| error!("Error: {}", e))

--- a/src/bin/toshi.rs
+++ b/src/bin/toshi.rs
@@ -176,7 +176,7 @@ fn connect_to_consul(settings: &Settings) -> impl Future<Item = (), Error = ()> 
     let settings_path_write = settings.path.clone();
 
     future::lazy(move || {
-        let mut consul_client = Consul::build()
+        let mut consul_client = Consul::builder()
             .with_cluster_name(cluster_name)
             .with_address(consul_address)
             .build()

--- a/src/cluster/consul.rs
+++ b/src/cluster/consul.rs
@@ -35,7 +35,7 @@ pub struct Consul {
 
 impl Consul {
     /// Create a builder instance
-    pub fn build() -> Builder {
+    pub fn builder() -> Builder {
         Builder::default()
     }
 

--- a/src/cluster/consul.rs
+++ b/src/cluster/consul.rs
@@ -28,36 +28,18 @@ pub type ConsulClient = TowerConsul<HttpsService>;
 pub struct Consul {
     address: String,
     scheme: Scheme,
-    cluster_name: Option<String>,
+    cluster_name: String,
     client: ConsulClient,
-    pub node_id: Option<String>,
+    node_id: String,
 }
 
 impl Consul {
-    /// Sets the address of the consul service
-    pub fn with_address(mut self, address: String) -> Self {
-        self.address = address;
-        self
+    /// Create a builder instance
+    pub fn build() -> Builder {
+        Builder::default()
     }
 
-    /// Sets the scheme (http or https) for the Consul server
-    pub fn with_scheme(mut self, scheme: Scheme) -> Self {
-        self.scheme = scheme;
-        self
-    }
-
-    /// Sets the *Toshi* cluster name
-    pub fn with_cluster_name(mut self, cluster_name: String) -> Self {
-        self.cluster_name = Some(cluster_name);
-        self
-    }
-
-    /// Sets the ID of this specific node in the Toshi cluster
-    pub fn with_node_id(mut self, node_id: String) -> Self {
-        self.node_id = Some(node_id);
-        self
-    }
-
+    /// Build the consul uri
     pub fn build_uri(self) -> Result<Uri> {
         Uri::builder()
             .scheme(self.scheme.clone())
@@ -103,29 +85,69 @@ impl Consul {
             .map_err(|err| ClusterError::FailedGettingIndex(format!("{:?}", err)))
     }
 
-    fn cluster_name(&self) -> String {
-        self.cluster_name.clone().unwrap()
+    /// Get a reference to the cluster name
+    pub fn cluster_name(&self) -> &String {
+        &self.cluster_name
     }
 
-    fn node_id(&self) -> String {
-        self.node_id.clone().unwrap()
+    /// Get a reference to the current node id
+    pub fn node_id(&self) -> &String {
+        &self.node_id
+    }
+
+    /// Set the node id for the current node
+    pub fn set_node_id(&mut self, new_id: String) {
+        self.node_id = new_id;
     }
 }
 
-impl Default for Consul {
-    fn default() -> Consul {
-        let client = match TowerConsul::new(HttpsService::new(), 100, "https".into(), "127.0.0.1:8500".into()) {
-            Ok(c) => c,
-            Err(_) => panic!("Unable to spawn"),
-        };
+#[derive(Default, Clone)]
+/// Builder struct for Consul
+pub struct Builder {
+    address: Option<String>,
+    scheme: Option<Scheme>,
+    cluster_name: Option<String>,
+    node_id: Option<String>,
+}
 
-        Consul {
-            address: "127.0.0.1:8500".into(),
-            scheme: Scheme::HTTP,
-            cluster_name: Some(String::from("kitsune")),
-            node_id: Some(String::from("alpha")),
+impl Builder {
+    /// Sets the address of the consul service
+    pub fn with_address(mut self, address: String) -> Self {
+        self.address = Some(address);
+        self
+    }
+
+    /// Sets the scheme (http or https) for the Consul server
+    pub fn with_scheme(mut self, scheme: Scheme) -> Self {
+        self.scheme = Some(scheme);
+        self
+    }
+
+    /// Sets the *Toshi* cluster name
+    pub fn with_cluster_name(mut self, cluster_name: String) -> Self {
+        self.cluster_name = Some(cluster_name);
+        self
+    }
+
+    /// Sets the ID of this specific node in the Toshi cluster
+    pub fn with_node_id(mut self, node_id: String) -> Self {
+        self.node_id = Some(node_id);
+        self
+    }
+
+    pub fn build(self) -> Result<Consul> {
+        let address = self.address.unwrap_or("127.0.0.1:8500".parse().unwrap());
+        let scheme = self.scheme.unwrap_or(Scheme::HTTP);
+
+        let client = TowerConsul::new(HttpsService::new(), 100, scheme.to_string(), address.to_string()).map_err(|_| Error::SpawnError)?;
+
+        Ok(Consul {
+            address,
+            scheme,
             client,
-        }
+            cluster_name: self.cluster_name.unwrap_or("kitsune".into()),
+            node_id: self.node_id.unwrap_or("alpha".into()),
+        })
     }
 }
 

--- a/src/cluster/placement_server.rs
+++ b/src/cluster/placement_server.rs
@@ -100,7 +100,7 @@ mod tests {
         let socket_addr: SocketAddr = "127.0.0.1:8081".parse().unwrap();
         let tcp_stream = Conn(socket_addr);
 
-        let service = Place::get_service(socket_addr, Consul::default());
+        let service = Place::get_service(socket_addr, Consul::builder().build().unwrap());
         let mut c = Connect::new(tcp_stream, Default::default(), DefaultExecutor::current());
 
         let place = c

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub enum Error {
     UnknownIndex(String),
     #[fail(display = "Query Parse Error: {}", _0)]
     QueryError(String),
+    #[fail(display = "Failed to find known executor")]
+    SpawnError,
 }
 
 impl From<TError> for Error {


### PR DESCRIPTION
This change also removes the `path` features in the cargo.toml for tower_consul since this was causing issues down stream.

This change also introduces a new `Builder` for the `Consul` struct. This allows us to remove a bunch of unwraps that lived within the consul code. This also separates the phase of _building_ the consul client and actually being able to use it. This is also important because the `build` function returns `Result<Consul>`. This is because to create the actual client we need to spawn a background task onto the tokio executor, this may fail if we are not yet in a futures context. This should make this error clearer instead of a panic.

This change is in reference to #71 