### PR TITLE
Allow contributing to Toshi from Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+ports:
+- port: 8080
+tasks:
+- init: cargo build --release && mkdir -p data
+  command: target/release/toshi

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ take it off the shelf and not modify it. My motivation was to cater to that use 
 #### Build Requirements
 At this current time Toshi should build and work fine on Windows, Mac OS X, and Linux. From dependency requirements you are going to need Rust >= 1.27 and Cargo installed in order to build.
 
+There is also a free pre-configured online build environment for Toshi:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://github.com/toshi-search/Toshi)
+
 #### Configuration
 
 There is a default configuration file in config/config.toml:


### PR DESCRIPTION
Hello! 👋

I work on https://gitpod.io, and we'd love to support Toshi by providing free pre-configured workspaces for Toshi developers, for example to help new contributors get started, and to make code reviews easier.

If you're interested, I've configured Gitpod to automatically build and run Toshi in release mode. Please let me know what you think. 😊

You can try it here:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/7d1e97e9-bf0a-438e-9c6b-f39763e6f79f)

<img width="1552" alt="screenshot 2019-01-15 at 10 48 52" src="https://user-images.githubusercontent.com/599268/51172272-2f1aaa00-18b3-11e9-8e6c-03f84a03d2ee.png">

Also, here is a treat for Toshi: ✨ 🍖 ✨