### PR TITLE
Replace futures mpsc and oneshot by tokio-sync

### DIFF
--- a/src/bin/toshi.rs
+++ b/src/bin/toshi.rs
@@ -6,9 +6,10 @@ use std::{
 };
 
 use clap::{crate_authors, crate_description, crate_version, App, Arg, ArgMatches};
-use futures::{future, sync::oneshot, Future, Stream};
+use futures::{future, Future, Stream};
 use log::{error, info};
 use tokio::runtime::Runtime;
+use tokio::sync::oneshot;
 
 use toshi::{
     cluster::{self, rpc_server::RpcServer, Consul},

--- a/src/cluster/placement/background.rs
+++ b/src/cluster/placement/background.rs
@@ -1,11 +1,12 @@
 use crate::cluster::{consul::Consul, ClusterError};
-use futures::{sync::mpsc, try_ready, Future, Poll};
+use futures::{try_ready, Future, Poll};
 use futures_watch::{Store, Watch};
 use log::debug;
 use std::collections::{HashSet, VecDeque};
 use std::hash::Hash;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
 use tokio::timer::Delay;
 use tower_consul::ConsulService;
 use tower_discover::Change;
@@ -93,8 +94,8 @@ impl From<ClusterError> for Error {
     }
 }
 
-impl From<mpsc::SendError<()>> for Error {
-    fn from(_: mpsc::SendError<()>) -> Self {
+impl From<mpsc::error::SendError> for Error {
+    fn from(_: mpsc::error::SendError) -> Self {
         Error::Send
     }
 }


### PR DESCRIPTION
The tokio team released the tokio-sync
crate which offers a mpsc and oneshot channel
analogous to the ones in the futures crate.

In some benchs, the new mpsc shows up to 7x improvement
over the futures version. The oneshot implementation
only provides a slight performance improvement, but when
updated to the std version of Future a much better
performance can be expected.

toshi-search#115