### PR TITLE
Abort if cluster fails to register on consul

### DIFF
--- a/src/bin/toshi.rs
+++ b/src/bin/toshi.rs
@@ -9,7 +9,6 @@ use clap::{crate_authors, crate_description, crate_version, App, Arg, ArgMatches
 use futures::{future, sync::oneshot, Future, Stream};
 use log::{error, info};
 use tokio::runtime::Runtime;
-use uuid::Uuid;
 
 use toshi::{
     cluster::{self, rpc_server::RpcServer, Consul},
@@ -192,8 +191,7 @@ fn run(catalog: Arc<RwLock<IndexCatalog>>, settings: &Settings) -> impl Future<I
 fn connect_to_consul(settings: &Settings) -> impl Future<Item = (), Error = ()> {
     let consul_address = settings.consul_addr.clone();
     let cluster_name = settings.cluster_name.clone();
-    let settings_path_read = settings.path.clone();
-    let settings_path_write = settings.path.clone();
+    let settings_path = settings.path.clone();
 
     future::lazy(move || {
         let mut consul_client = Consul::builder()
@@ -205,23 +203,10 @@ fn connect_to_consul(settings: &Settings) -> impl Future<Item = (), Error = ()> 
         // Build future that will connect to Consul and register the node_id
         consul_client
             .register_cluster()
-            .and_then(move |_| {
-                cluster::read_node_id(settings_path_read.as_str())
-                    .then(|result| match result {
-                        Ok(id) => {
-                            let parsed_id = Uuid::parse_str(&id).expect("Parsed node ID is not a UUID.");
-                            cluster::write_node_id(settings_path_write, parsed_id.to_hyphenated().to_string())
-                        }
-
-                        Err(_) => {
-                            let new_id = Uuid::new_v4();
-                            cluster::write_node_id(settings_path_write, new_id.to_hyphenated().to_string())
-                        }
-                    })
-                    .and_then(move |id| {
-                        consul_client.set_node_id(id);
-                        consul_client.register_node()
-                    })
+            .and_then(|_| cluster::init_node_id(settings_path))
+            .and_then(move |id| {
+                consul_client.set_node_id(id);
+                consul_client.register_node()
             })
             .map_err(|e| error!("Error: {}", e))
     })

--- a/src/cluster/node.rs
+++ b/src/cluster/node.rs
@@ -19,12 +19,12 @@ static NODE_ID_FILENAME: &'static str = ".node_id";
 
 /// Init the node id by reading the node id from path or writing a fresh one if not found
 pub fn init_node_id(path: String) -> impl Future<Item = String, Error = ClusterError> {
-    self::read_node_id(path.as_ref()).then(|result| {
+    read_node_id(path.as_ref()).then(|result| {
         let id = match result {
             Ok(id) => Uuid::parse_str(&id).expect("Parsed node ID is not a UUID."),
             Err(_) => Uuid::new_v4(),
         };
-        self::write_node_id(path, id.to_hyphenated().to_string())
+        write_node_id(path, id.to_hyphenated().to_string())
     })
 }
 

--- a/src/cluster/node.rs
+++ b/src/cluster/node.rs
@@ -10,10 +10,23 @@ use tokio::{
     io::{read_to_end, write_all},
 };
 
+use uuid::Uuid;
+
 use std::path::Path;
 use std::time;
 
 static NODE_ID_FILENAME: &'static str = ".node_id";
+
+/// Init the node id by reading the node id from path or writing a fresh one if not found
+pub fn init_node_id(path: String) -> impl Future<Item = String, Error = ClusterError> {
+    self::read_node_id(path.as_ref()).then(|result| {
+        let id = match result {
+            Ok(id) => Uuid::parse_str(&id).expect("Parsed node ID is not a UUID."),
+            Err(_) => Uuid::new_v4(),
+        };
+        self::write_node_id(path, id.to_hyphenated().to_string())
+    })
+}
 
 /// Write node id to the path `p` provided, this will also append `.node_id`
 pub fn write_node_id(p: String, id: String) -> impl Future<Item = String, Error = ClusterError> {


### PR DESCRIPTION
If the cluster fails to register we can abort
immediately avoiding it to fail again in the
node registration with a misleading error.

 #114