### PR TITLE
Fix the example document submission URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Now you can add documents to our index. The `options` field can be omitted if a 
 
 ```bash
 curl -X PUT \
-  http://localhost:8080/test_index/_create \
+  http://localhost:8080/test_index \
   -H 'Content-Type: application/json' \
   -d '{
         "options": { "commit": true },


### PR DESCRIPTION
As written, it expects a Schema document, and fails with an error

```console
$ git rev-parse HEAD
4315302fc3e6cf24fafd14cc9e2c4a40b8c40932
$ cargo build
$ ./target/debug/toshi
```
then, running [the index creation](https://github.com/toshi-search/Toshi/blame/4315302fc3e6cf24fafd14cc9e2c4a40b8c40932/README.md#L163-L194) does result in `201 Created`, but running [the put document command](https://github.com/toshi-search/Toshi/blame/4315302fc3e6cf24fafd14cc9e2c4a40b8c40932/README.md#L202-L212) produces an error message:

```json
{"message":"Error in query execution: 'invalid type: map, expected struct Schema at line 1 column 0'"}
```

_(apologies for the "blame" links, I needed the line numbers)_