### PR TITLE
Make sure we read all of the response body

### DIFF
--- a/toshi-client/src/hyper_client.rs
+++ b/toshi-client/src/hyper_client.rs
@@ -1,6 +1,5 @@
 use std::fmt::Display;
 
-use bytes::Buf;
 use http::Response;
 use hyper::client::connect::Connect;
 use hyper::{Body, Client, Request, Uri};
@@ -46,8 +45,8 @@ where
         R: DeserializeOwned + Send + Sync,
     {
         let response = self.client.request(request).await?;
-        let body = hyper::body::aggregate(response.into_body()).await?;
-        serde_json::from_slice::<R>(body.bytes()).map_err(Into::into)
+        let body_bytes = hyper::body::to_bytes(response.into_body()).await?;
+        serde_json::from_slice::<R>(&body_bytes).map_err(Into::into)
     }
 
     pub async fn index(&self) -> Result<Response<Body>> {

--- a/toshi-server/src/handlers/search.rs
+++ b/toshi-server/src/handlers/search.rs
@@ -1,5 +1,4 @@
-use bytes::Buf;
-use hyper::body::aggregate;
+use hyper::body::to_bytes;
 use hyper::Response;
 use hyper::{Body, StatusCode};
 use log::info;
@@ -17,8 +16,8 @@ pub fn fold_results(results: Vec<SearchResults>, limit: usize) -> SearchResults 
 }
 
 pub async fn doc_search(catalog: SharedCatalog, body: Body, index: &str) -> ResponseFuture {
-    let b = aggregate(body).await?;
-    let req = serde_json::from_slice::<Search>(b.bytes()).unwrap();
+    let b = to_bytes(body).await?;
+    let req = serde_json::from_slice::<Search>(&b).unwrap();
     let req = if req.query.is_none() { Search::all_limit(req.limit) } else { req };
 
     if catalog.exists(index) {

--- a/toshi-test/src/lib.rs
+++ b/toshi-test/src/lib.rs
@@ -1,6 +1,5 @@
 use std::net::{SocketAddr, TcpListener};
 
-use bytes::Buf;
 use futures::future::Either;
 use futures::Future;
 use http::uri::{Authority, Scheme};
@@ -50,8 +49,7 @@ pub fn cmp_float(a: f32, b: f32) -> bool {
 }
 
 pub async fn read_body(resp: Response<Body>) -> Result<String, Box<dyn std::error::Error>> {
-    let body = hyper::body::aggregate(resp.into_body()).await?;
-    let b = body.bytes();
+    let b = hyper::body::to_bytes(resp.into_body()).await?;
     Ok(String::from_utf8(b.to_vec())?)
 }
 


### PR DESCRIPTION
I was seeing intermittent JSON parsing errors which seemed to be a result of passing incomplete JSON content to serde_json. I discovered reading the documentation for Buf::bytes that it states "Note that this can return shorter slice (this allows non-continuous internal representation)." and so calling Buf::bytes may not return all of the content in the buffer, which was happening in this case and causing the errors I was seeing - change usages of Buf::bytes to use to_bytes to read the entire body to avoid this possibility.