### PR TITLE
toshi-client fixes

### DIFF
--- a/toshi-client/src/hyper_client.rs
+++ b/toshi-client/src/hyper_client.rs
@@ -81,7 +81,7 @@ where
         self.client.request(request).await.map_err(Into::into)
     }
 
-    async fn add_document<I, D>(&self, index: String, options: Option<IndexOptions>, document: D) -> Result<Response<Self::Body>>
+    async fn add_document<I, D>(&self, index: I, options: Option<IndexOptions>, document: D) -> Result<Response<Self::Body>>
     where
         I: ToString + Send + Sync + Display,
         D: Serialize + Send + Sync,

--- a/toshi-client/src/hyper_client.rs
+++ b/toshi-client/src/hyper_client.rs
@@ -88,7 +88,7 @@ where
     {
         let uri = self.uri(index);
         let body = serde_json::to_vec(&AddDocument { options, document })?;
-        let request = Request::post(uri).body(Body::from(body))?;
+        let request = Request::put(uri).body(Body::from(body))?;
         self.client.request(request).await.map_err(Into::into)
     }
 
@@ -109,7 +109,7 @@ where
         D: DeserializeOwned + Clone + Send + Sync,
     {
         let uri = self.uri(index);
-        let request = Request::post(uri).body(Body::empty())?;
+        let request = Request::get(uri).body(Body::empty())?;
         self.make_request::<SearchResults<D>>(request).await
     }
 }

--- a/toshi-client/src/isahc_client.rs
+++ b/toshi-client/src/isahc_client.rs
@@ -64,7 +64,7 @@ impl Client for ToshiClient {
         self.client.put(uri, body).map_err(Into::into)
     }
 
-    async fn add_document<I, D>(&self, index: String, options: Option<IndexOptions>, document: D) -> Result<Response<Body>>
+    async fn add_document<I, D>(&self, index: I, options: Option<IndexOptions>, document: D) -> Result<Response<Body>>
     where
         I: ToString + Send + Sync + Display,
         D: Serialize + Send + Sync,

--- a/toshi-client/src/isahc_client.rs
+++ b/toshi-client/src/isahc_client.rs
@@ -71,7 +71,7 @@ impl Client for ToshiClient {
     {
         let uri = self.uri(index);
         let body = serde_json::to_vec(&AddDocument { options, document })?;
-        self.client.post(uri, body).map_err(Into::into)
+        self.client.put(uri, body).map_err(Into::into)
     }
 
     async fn search<I, D>(&self, index: I, search: Search) -> Result<SearchResults<D>>

--- a/toshi-client/src/lib.rs
+++ b/toshi-client/src/lib.rs
@@ -35,7 +35,7 @@ pub trait Client {
     where
         I: ToString + Send + Sync + Display;
 
-    async fn add_document<I, D>(&self, index: String, options: Option<IndexOptions>, document: D) -> Result<Response<Self::Body>>
+    async fn add_document<I, D>(&self, index: I, options: Option<IndexOptions>, document: D) -> Result<Response<Self::Body>>
     where
         I: ToString + Send + Sync + Display,
         D: Serialize + Send + Sync;


### PR DESCRIPTION
This fixes a couple of issues in the toshi-client crate:

* Some of the HTTP methods used in the clients weren't correct, I've changed these to use PUT for add_document and GET for all_docs, matching [docs/api.raml](https://github.com/toshi-search/Toshi/blob/master/docs/api.raml).
* In some of the client methods, a type parameter `I` was declared and I assume was intended to be used for the type of the index parameter, but `String` was used instead - change this to `I` so that it can also accept `&str`, etc.